### PR TITLE
remove emacs-china.org from direct

### DIFF
--- a/direct.txt
+++ b/direct.txt
@@ -21400,7 +21400,6 @@ xz.pphimalayanrt.com
 .elvshi.com
 .elvxing.net
 .elxk.com
-.emacs-china.org
 .emadao.com
 .emaileds.com
 .emailflame.com


### PR DESCRIPTION
According to: https://emacs-china.org/t/topic/21439 emacs-china 已经迁移到国外，direct 无法访问。