### PR TITLE
Change star history service to star-history.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,4 +252,4 @@ FINAL,DIRECT,dns-failed
 
 ## 项目 Star 数增长趋势
 
-[![Stargazers over time](https://starchart.cc/Loyalsoldier/surge-rules.svg)](https://starchart.cc/Loyalsoldier/surge-rules)
+[![Star History Chart](https://api.star-history.com/svg?repos=Loyalsoldier/surge-rules&type=Date)](https://star-history.com/#Loyalsoldier/surge-rules&Date)


### PR DESCRIPTION
The old star history service seems broken in the README, so I changed it to use [star-history.com](https://star-history.com/#Loyalsoldier/surge-rules&Date).

Before:

![图片](https://user-images.githubusercontent.com/1446531/237062191-5dfb33d5-0ded-4b5b-88b4-fb40b927b667.png)

After:

![图片](https://user-images.githubusercontent.com/1446531/237062484-a12ca000-4dec-4656-9c4b-90648659ae1c.png)
