### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,4 +1,6 @@
 name: Generate routing rules for Surge
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Loyalsoldier/surge-rules/security/code-scanning/1](https://github.com/Loyalsoldier/surge-rules/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/run.yml` at the workflow root (top-level, alongside `name` and `on`) so all jobs inherit it.  
For this workflow’s existing behavior, the minimal practical permissions are:

- `contents: write` (required for creating releases and pushing commits/branch updates)

No other scopes are required by the shown steps. This preserves existing functionality while removing implicit/default token privilege behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
